### PR TITLE
⚡️ Use correct terms and improve clarity

### DIFF
--- a/Lessons/day-02-functions.md
+++ b/Lessons/day-02-functions.md
@@ -1,6 +1,6 @@
 # Day 2 - Functions
 
-Today's lesson we will start on functions. Functions are a first class citizen in F#, which they are meant to be in C# too, but in a lesser way. In C# there are Method Groups which are the functions you define on your classes, static or otherwise. You also have `Func<T>` and `Action<T>`, which is what you pass into methods like Linq Select, Where, statements. A Method Group is different to a `Func` or `Action`, although it can be cast to one when necessary. You all know how to make a method group in C#
+Today's lesson we will start on functions. Functions are first class citizens in F#. This means that functions are regular values just like other variables. In C# there are methods which are the functions you define on your classes, static or otherwise. You also have `Func<T>` and `Action<T>`, which are what you pass into methods like Linq `Select`, `Where`, statements. A method is different to a `Func` or `Action`, although it can be cast to one when necessary. Those coming from C# know how to create methods in the following manner:
 
 ```csharp
 public class Example
@@ -28,18 +28,19 @@ public class Example
 }
 ```
 
-In F# a function is very much a first class citizen, of which there are two types, but we'll start with the one you'd probably find easier to read, although it is used less, for reasons I'll explain tomorrow as this has taken too long going over C# stuff :wink:
+F# functions are first class citizens in the F# language. There are two types of functions: `curried` and `tupled`. The following `tupled` function is more familiar coming from C# and other _C Style_ languages:
 
 ```fsharp
 // Function definition
 let sum(x, y) = x + y
 let result = sum(1, 2)
+
 printf "%d" result
 ```
 
 [Try the code](https://try.fsharp.org/#?code=LAKA9GAEBiCuB2BjALgSwPb0gEwKYDNV5U1NQAbXZSAZ1gFsAKADwBpIBPASkgF5JmkANSdQEGAhQYssGgEMA5rgpVIAJ1x1y1fnSYBGdgCYuoUAAc1RZPkgAiAKTY76zbG1A&html=DwCwLgtgNgfAsAKAAQqaApgQwCb2ag4CdMTJcMABwFp0BHAVwEsA3AXgCIBhAewDsw6AdQAqAT0roOSAMb9BAzoIAeYAPThoAbhkhMAJwDOJNgzAAzagA4OeQhqy5EhAEY9sYu6mBq3HvD6asEA&css=Q)
 
-You may notice that there is no need to define the types of those arguments, that is because the F# compiler can extrapolate the types you want based on the fact you are using the + operator on them. That may be scary at first, but don't worry, when looking at it in an IDE it will tell you what the signature is, often shown above in something similar to this:
+You may notice that there is no need to define the types of those arguments, that is because the F# compiler can infer the types you want based on how you use them. In this case the fact you are using the + operator on them gives the compiler a hint that they are integers. That may be scary at first, but don't worry, when looking at it in an IDE it will tell you what the signature is, often shown above in something similar to this:
 
 ```fsharp
 int * int -> int


### PR DESCRIPTION
- `Method Groups` are specifically for a set of methods that share an overload. The term is just methods :). Also using the word `infer` over `extrapolate` is more consistent with how people talk about type inference. 